### PR TITLE
Updates Usage Example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ uses: reggionick/s3-deploy@v3
 with:
     folder: build
     bucket: ${{ secrets.S3_BUCKET }}
-    dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+    bucket-region: us-east-1
 ```
 
 ## Arguments


### PR DESCRIPTION
Fixes: #45

Adds required `bucket-region:` to usage example and removes optional `dist-id:`.
us-east-1 is default bucket region for S3 but users can change it if they wish.