### PR TITLE
Add filesToInlcude Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Input              | Type             | Required | Default      | Description
 | `noCache`        | boolean          | No       | false        | Use this parameter to specify `Cache-Control: no-cache, no-store, must-revalidate` header 
 | `private`        | boolean          | No       | false        | Upload files with private ACL, needed for S3 static website hosting
 | `cache`          | string           | No       |              | Sets the Cache-Control: max-age=X header
+| `filesToInclude` | string           | No       | **           | Allows for a comma delineated Regex String that matches files to include in the deployment
 
 
 ### Example `workflow.yml` with S3 Deploy Action
@@ -64,6 +65,7 @@ jobs:
             delete-removed: true
             no-cache: true
             private: true
+            filesToInclude: ".*/*,*/*,**"
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Input              | Type             | Required | Default      | Description
 | `noCache`        | boolean          | No       | false        | Use this parameter to specify `Cache-Control: no-cache, no-store, must-revalidate` header 
 | `private`        | boolean          | No       | false        | Upload files with private ACL, needed for S3 static website hosting
 | `cache`          | string           | No       |              | Sets the Cache-Control: max-age=X header
-| `filesToInclude` | string           | No       | **           | Allows for a comma delineated Regex String that matches files to include in the deployment
+| `filesToInclude` | string           | No       | "**"           | Allows for a comma delineated Regex String that matches files to include in the deployment
 
 
 ### Example `workflow.yml` with S3 Deploy Action

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
   cache:
     description: 'Sets the Cache-Control: max-age=X header'
     required: false
+  filesToInclude:
+    description: 'Allows for a comma delineated Regex String that matches files to include in the deployment'
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/deploy.js
+++ b/deploy.js
@@ -3,7 +3,7 @@ const exec = require('@actions/exec');
 
 let deploy = function (params) {
   return new Promise((resolve, reject) => {
-    const { folder, bucket, bucketRegion, distId, invalidation, deleteRemoved, noCache, private, cache } = params;
+    const { folder, bucket, bucketRegion, distId, invalidation, deleteRemoved, noCache, private, cache, filesToInclude } = params;
 
     const distIdArg = distId ? `--distId ${distId}` : '';
     const invalidationArg = distId ? `--invalidate "${invalidation}"` : '';
@@ -16,9 +16,10 @@ let deploy = function (params) {
     const noCacheArg = noCache ? '--noCache' : '';
     const privateArg = private ? '--private' : '';
     const cacheFlag  = cache ? `--cache ${cache}` : '';
+    const filesRegex = filesToInclude ? filesToInclude : '**';  
 
     try {
-      const command = `npx s3-deploy@1.4.0 ./** \
+      const command = `npx s3-deploy@1.4.0 ./${filesRegex} \
                         --bucket ${bucket} \
                         --region ${bucketRegion} \
                         --cwd ./ \

--- a/index.js
+++ b/index.js
@@ -16,8 +16,9 @@ async function run() {
     const noCache = getBooleanInput('no-cache');
     const private = getBooleanInput('private');
     const cache   = core.getInput('cache') || null;
+    const filesToInclude = core.getInput('files-to-include') || null;
 
-    await deploy({ folder, bucket, bucketRegion, distId, invalidation, deleteRemoved, noCache, private, cache });
+    await deploy({ folder, bucket, bucketRegion, distId, invalidation, deleteRemoved, noCache, private, cache, filesToInclude });
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2131,7 +2131,6 @@
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2327,8 +2326,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2418,8 +2416,7 @@
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },


### PR DESCRIPTION
Simply this just adds a String input `filesToInlcude` that takes a string of files to include.

I was unable to build/run locally because there was no reference to an example .env file so i wasn't sure what is needed if its just the AWS creds or something more. 

Is a dist folder of a proper PR or will the build and usage do it in your pipeline? If so can you help me set it up to properly build?

Following this previously accepted PR. https://github.com/Reggionick/s3-deploy/commit/c1eb453ea98b38c6078d420307d4e5e5298b4bf7