### PR TITLE
Fix docs regarding files-to-include parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,34 +11,33 @@ You can use this action by referencing the v3 branch
 ```yaml
 uses: reggionick/s3-deploy@v3
 with:
-    folder: build
-    bucket: ${{ secrets.S3_BUCKET }}
-    bucket-region: us-east-1
+  folder: build
+  bucket: ${{ secrets.S3_BUCKET }}
+  bucket-region: us-east-1
 ```
 
 ## Arguments
 
 S3 Deploy's Action supports inputs from the user listed in the table below:
 
-Input              | Type             | Required | Default      | Description
------------------- | ---------------- | -------- | ------------ | -----------
-| `folder`         | string           | Yes      |              | The folder to upload 
-| `bucket`         | string           | Yes      |              | The destination bucket 
-| `bucket-region`  | string           | Yes      |              | The destination bucket region
-| `dist-id`        | string           | No       | undefined    | The CloudFront Distribution ID to invalidate
-| `invalidation`   | string           | No       | '/'          | The CloudFront Distribution path(s) to invalidate
-| `delete-removed` | boolean / string | No       | false        | Removes files in S3, that are not available in the local copy of the directory 
-| `noCache`        | boolean          | No       | false        | Use this parameter to specify `Cache-Control: no-cache, no-store, must-revalidate` header 
-| `private`        | boolean          | No       | false        | Upload files with private ACL, needed for S3 static website hosting
-| `cache`          | string           | No       |              | Sets the Cache-Control: max-age=X header
-| `filesToInclude` | string           | No       | "**"           | Allows for a comma delineated Regex String that matches files to include in the deployment
-
+| Input              | Type             | Required | Default   | Description                                                                               |
+|--------------------|------------------|----------|-----------|-------------------------------------------------------------------------------------------|
+| `folder`           | string           | Yes      |           | The folder to upload                                                                      |
+| `bucket`           | string           | Yes      |           | The destination bucket                                                                    |
+| `bucket-region`    | string           | Yes      |           | The destination bucket region                                                             |
+| `dist-id`          | string           | No       | undefined | The CloudFront Distribution ID to invalidate                                              |
+| `invalidation`     | string           | No       | '/'       | The CloudFront Distribution path(s) to invalidate                                         |
+| `delete-removed`   | boolean / string | No       | false     | Removes files in S3, that are not available in the local copy of the directory            |
+| `no-cache`         | boolean          | No       | false     | Use this parameter to specify `Cache-Control: no-cache, no-store, must-revalidate` header |
+| `private`          | boolean          | No       | false     | Upload files with private ACL, needed for S3 static website hosting                       |
+| `cache`            | string           | No       |           | Sets the Cache-Control: max-age=X header                                                  |
+| `files-to-include` | string           | No       | "**"      | Allows for a glob pattern that matches files to include in the deployment                 |
 
 ### Example `workflow.yml` with S3 Deploy Action
 
 ```yaml
 name: Example workflow for S3 Deploy
-on: [push]
+on: [ push ]
 jobs:
   run:
     runs-on: ubuntu-latest
@@ -46,26 +45,26 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
-        - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-        - name: Install dependencies
-          run: yarn
+      - name: Install dependencies
+        run: yarn
 
-        - name: Build
-          run: yarn build
+      - name: Build
+        run: yarn build
 
-        - name: Deploy
-          uses: reggionick/s3-deploy@v3
-          with:
-            folder: build
-            bucket: ${{ secrets.S3_BUCKET }}
-            bucket-region: ${{ secrets.S3_BUCKET_REGION }}
-            dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-            invalidation: /
-            delete-removed: true
-            no-cache: true
-            private: true
-            filesToInclude: ".*/*,*/*,**"
+      - name: Deploy
+        uses: reggionick/s3-deploy@v3
+        with:
+          folder: build
+          bucket: ${{ secrets.S3_BUCKET }}
+          bucket-region: ${{ secrets.S3_BUCKET_REGION }}
+          dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+          invalidation: /
+          delete-removed: true
+          no-cache: true
+          private: true
+          files-to-include: "{.*/*,*/*,**}"
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -28,8 +28,8 @@ inputs:
   cache:
     description: 'Sets the Cache-Control: max-age=X header'
     required: false
-  filesToInclude:
-    description: 'Allows for a comma delineated Regex String that matches files to include in the deployment'
+  files-to-include:
+    description: 'Allows for a glob pattern that matches files to include in the deployment'
     required: false
 runs:
   using: 'node12'


### PR DESCRIPTION
Most notably there was missing `{}` in the example and I think it's more accurate to say that the parameter is a glob pattern rather than coma separated regex.

There was also issue with camel case that #89 is also addressing.

I also autofomatted the README file:
- consistent 2 spacing for yaml
- each row in table should start and end with |