### PR TITLE
Add ''root:true'' to eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,17 +1,17 @@
 {
-    "env": {
-        "commonjs": true,
-        "es6": true,
-        "node": true
-    },
-    "extends": "eslint:recommended",
-    "globals": {
-        "Atomics": "readonly",
-        "SharedArrayBuffer": "readonly"
-    },
-    "parserOptions": {
-        "ecmaVersion": 2018
-    },
-    "rules": {
-    }
+  "root": true,
+  "env": {
+    "commonjs": true,
+    "es6": true,
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "globals": {
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
+  },
+  "parserOptions": {
+    "ecmaVersion": 2018
+  },
+  "rules": {}
 }


### PR DESCRIPTION
This fixes the deprecation warning.

![image](https://user-images.githubusercontent.com/1212885/220601920-815bdb9c-977b-491e-b1ce-4b6fa1041bad.png)

File is formatted with Prettier so indents changed to 2.