### PR TITLE
Fix casing typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ S3 Deploy's Action supports inputs from the user listed in the table below:
 | `dist-id`          | string           | No       | undefined | The CloudFront Distribution ID to invalidate                                               |
 | `invalidation`     | string           | No       | '/'       | The CloudFront Distribution path(s) to invalidate                                          |
 | `delete-removed`   | boolean / string | No       | false     | Removes files in S3, that are not available in the local copy of the directory             |
-| `noCache`          | boolean          | No       | false     | Use this parameter to specify `Cache-Control: no-cache, no-store, must-revalidate` header  |
+| `no-cache`         | boolean          | No       | false     | Use this parameter to specify `Cache-Control: no-cache, no-store, must-revalidate` header  |
 | `private`          | boolean          | No       | false     | Upload files with private ACL, needed for S3 static website hosting                        |
 | `cache`            | string           | No       |           | Sets the Cache-Control: max-age=X header                                                   |
 | `immutable`        | boolean          | No       | false     | Sets the Cache-Control header to 'immutable'                                               |


### PR DESCRIPTION
In the example a few lines lower, `no-cache` is used, so I assume they're either interchangeable or the one in the table was a typo.