### PR TITLE
Update checkout action to v5 in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
Upgraded the GitHub Actions 'checkout' step from v3 to v5 and set 'persist-credentials' to false for improved security and compatibility.